### PR TITLE
Fixed capitalization typo in url

### DIFF
--- a/nbody/index.md
+++ b/nbody/index.md
@@ -13,7 +13,7 @@ You can download the skeleton code from the snarf site using Ambient, or the equ
 
 You can also view/download the NBody class here:
 
-[Nbody.java](/nbody/code/Nbody.html)
+[NBody.java](/nbody/code/NBody.html)
 
 We suggest you read the "Equations Behind NBody", "Program Specifications", and "Suggestions/How To" sections before writing any code.
 


### PR DESCRIPTION
NBody main page link was 404ing because it was Nbody.html, not NBody.html
